### PR TITLE
Lazily load the dictionary

### DIFF
--- a/lib/profanity_filter.rb
+++ b/lib/profanity_filter.rb
@@ -36,9 +36,12 @@ module ProfanityFilter
     cattr_accessor :replacement_text, :dictionary_file, :dictionary
     @@replacement_text = '@#$%'
     @@dictionary_file  = File.join(File.dirname(__FILE__), '../config/dictionary.yml')
-    @@dictionary       = YAML.load_file(@@dictionary_file)
 
     class << self
+      def dictionary
+        @@dictionary ||= YAML.load_file(@@dictionary_file)
+      end
+      
       def banned?(word = '')
         dictionary.include?(word.downcase) if word
       end


### PR DESCRIPTION
Hey, 

I needed to load an alternate dictionary and didn't want the default dictionary to be loaded first.
So I've made this small change.
I can then set dictionary_file before the dictionary is loaded.

Thanks for this gem.
