### PR TITLE
Added the ability to add and remove from the gem's distributed dictionary.

### DIFF
--- a/lib/profanity_filter.rb
+++ b/lib/profanity_filter.rb
@@ -50,8 +50,9 @@ module ProfanityFilter
           #SO... lets override the save method.
           define_method "save" do |*args|
             unbind_profanity
-            super(*args)
+            result = super(*args)
             bind_profanity
+            return result
           end
         end
       end

--- a/lib/profanity_filter.rb
+++ b/lib/profanity_filter.rb
@@ -43,8 +43,16 @@ module ProfanityFilter
       end
       
       def append_dictionary( file )
-        dictionary #Insure the dictionary is loaded
-        @@dictionary = @@dictionary.merge(YAML.load_file( file ) )
+        @@dictionary = dictionary.merge(YAML.load_file( file ) )
+      end
+      
+      def remove_from_dictionary( file )
+        excluded_words = YAML.load_file( file )
+        if excluded_words
+          dictionary.keep_if do |dictionary_word|
+            !( excluded_words.include?(dictionary_word) )
+          end
+        end
       end
       
       def banned?(word = '')

--- a/lib/profanity_filter.rb
+++ b/lib/profanity_filter.rb
@@ -29,7 +29,12 @@ module ProfanityFilter
                 class << self
                   undef_method :#{attr_name}
                   def #{attr_name}
-                    @attributes[%q(#{attr_name})]
+                    v = @attributes[%q(#{attr_name})]
+                    if v.kind_of?(String)
+                      v
+                    elsif v.respond_to?(:value)
+                      v.value
+                    end
                   end
                 end
               )

--- a/lib/profanity_filter.rb
+++ b/lib/profanity_filter.rb
@@ -42,6 +42,11 @@ module ProfanityFilter
         @@dictionary ||= YAML.load_file(@@dictionary_file)
       end
       
+      def append_dictionary( file )
+        dictionary #Insure the dictionary is loaded
+        @@dictionary = @@dictionary.merge(YAML.load_file( file ) )
+      end
+      
       def banned?(word = '')
         dictionary.include?(word.downcase) if word
       end


### PR DESCRIPTION
The following functions have been added to the ProfanityFilter::Base:

append_dictionary( <file path> ) - This will load the supplied yml file and merge it with the existing dictionary.
remove_from_dictionary( <file path> ) - This will load the supplied yml file and remove the keys in the supplied yml file from the current dictionary.

Example initializer for a Rails project:

profanity.rb:
ProfanityFilter::Base.append_dictionary(File.join(Rails.root,"/config/profanity.yml"))
ProfanityFilter::Base.remove_from_dictionary(File.join(Rails.root,"/config/profanity_exclude.yml"))
