### PR TITLE
check if ActiveRecord::Base is defined before `send`ing it :include

### DIFF
--- a/lib/profanity_filter.rb
+++ b/lib/profanity_filter.rb
@@ -87,4 +87,4 @@ module ProfanityFilter
   end
 end
 
-ActiveRecord::Base.send(:include, ProfanityFilter) if defined?(ActiveRecord)
+ActiveRecord::Base.send(:include, ProfanityFilter) if defined?(ActiveRecord::Base)


### PR DESCRIPTION
Some project which don't use ActiveRecord may have `ActiveRecord` (the constant)
defined
