### PR TITLE
Check if ActiveRecord::Base is defined, not just ActiveRecord

### DIFF
--- a/lib/profanity_filter.rb
+++ b/lib/profanity_filter.rb
@@ -87,4 +87,4 @@ module ProfanityFilter
   end
 end
 
-ActiveRecord::Base.send(:include, ProfanityFilter) if defined?(ActiveRecord)
+ActiveRecord::Base.send(:include, ProfanityFilter) if defined?(ActiveRecord::Base)


### PR DESCRIPTION
Fixes an error on Rails load:

Stack trace:

``` shell
rake-0.9.2.2/lib/rake/ext/module.rb:36:in `const_missing': uninitialized constant ActiveRecord::Base (NameError)
profanity_filter-0.1.1/lib/profanity_filter.rb:90:in `<top (required)>'
< ... snip ... >
```
